### PR TITLE
If no tracks exist, return no image data instead of crashing.

### DIFF
--- a/DSWaveformImage/DSWaveformImage.m
+++ b/DSWaveformImage/DSWaveformImage.m
@@ -137,6 +137,7 @@
 - (NSData *)renderPNGAudioPictogramLogForAssett:(AVURLAsset *)songAsset withSize:(CGSize)size {
   NSError *error = nil;
   AVAssetReader *reader = [[AVAssetReader alloc] initWithAsset:songAsset error:&error];
+  if ([songAsset.tracks count] == 0) return nil;
   AVAssetTrack *songTrack = [songAsset.tracks objectAtIndex:0];
 
   NSDictionary *outputSettingsDict = [[NSDictionary alloc] initWithObjectsAndKeys:


### PR DESCRIPTION
If no tracks exist, return no image data instead of crashing.
