### PR TITLE
Carthage Support

### DIFF
--- a/DSWaveformImageExample.xcodeproj/project.pbxproj
+++ b/DSWaveformImageExample.xcodeproj/project.pbxproj
@@ -26,6 +26,13 @@
 		C3790A181828CA3A0033D193 /* DSWaveformImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = C3790A161828CA3A0033D193 /* DSWaveformImageView.m */; };
 		C3790A1A1828CA740033D193 /* example_sound.m4a in Resources */ = {isa = PBXBuildFile; fileRef = C3790A191828CA740033D193 /* example_sound.m4a */; };
 		C3790A1C1828CC2D0033D193 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C3790A1B1828CC2D0033D193 /* AVFoundation.framework */; };
+		D6EABC4C1D6C010700C5862C /* DSWaveformImageFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = D6EABC4B1D6C010700C5862C /* DSWaveformImageFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6EABC5E1D6C010700C5862C /* DSWaveformImageFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6EABC491D6C010700C5862C /* DSWaveformImageFramework.framework */; };
+		D6EABC5F1D6C010700C5862C /* DSWaveformImageFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D6EABC491D6C010700C5862C /* DSWaveformImageFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D6EABC671D6C011600C5862C /* DSWaveformImage.m in Sources */ = {isa = PBXBuildFile; fileRef = C3790A141828CA3A0033D193 /* DSWaveformImage.m */; };
+		D6EABC681D6C011600C5862C /* DSWaveformImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = C3790A161828CA3A0033D193 /* DSWaveformImageView.m */; };
+		D6EABC691D6C063000C5862C /* DSWaveformImage.h in Headers */ = {isa = PBXBuildFile; fileRef = C3790A131828CA3A0033D193 /* DSWaveformImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D6EABC6A1D6C063600C5862C /* DSWaveformImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = C3790A151828CA3A0033D193 /* DSWaveformImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,7 +43,28 @@
 			remoteGlobalIDString = C37909D61828C9D80033D193;
 			remoteInfo = DSWaveformImageExample;
 		};
+		D6EABC5C1D6C010700C5862C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C37909CF1828C9D80033D193 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D6EABC481D6C010700C5862C;
+			remoteInfo = DSWaveformImageFramework;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D6EABC651D6C010700C5862C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D6EABC5F1D6C010700C5862C /* DSWaveformImageFramework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		C37909D71828C9D80033D193 /* DSWaveformImageExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DSWaveformImageExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -65,6 +93,9 @@
 		C3790A161828CA3A0033D193 /* DSWaveformImageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DSWaveformImageView.m; sourceTree = "<group>"; };
 		C3790A191828CA740033D193 /* example_sound.m4a */ = {isa = PBXFileReference; lastKnownFileType = file; path = example_sound.m4a; sourceTree = "<group>"; };
 		C3790A1B1828CC2D0033D193 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		D6EABC491D6C010700C5862C /* DSWaveformImageFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DSWaveformImageFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6EABC4B1D6C010700C5862C /* DSWaveformImageFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DSWaveformImageFramework.h; sourceTree = "<group>"; };
+		D6EABC4D1D6C010700C5862C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +107,7 @@
 				C37909DD1828C9D80033D193 /* CoreGraphics.framework in Frameworks */,
 				C37909DF1828C9D80033D193 /* UIKit.framework in Frameworks */,
 				C37909DB1828C9D80033D193 /* Foundation.framework in Frameworks */,
+				D6EABC5E1D6C010700C5862C /* DSWaveformImageFramework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,6 +121,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6EABC451D6C010700C5862C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -98,6 +137,7 @@
 				C3790A121828CA3A0033D193 /* DSWaveformImage */,
 				C37909E01828C9D80033D193 /* DSWaveformImageExample */,
 				C3790A021828C9D80033D193 /* DSWaveformImageExampleTests */,
+				D6EABC4A1D6C010700C5862C /* DSWaveformImageFramework */,
 				C37909D91828C9D80033D193 /* Frameworks */,
 				C37909D81828C9D80033D193 /* Products */,
 			);
@@ -108,6 +148,7 @@
 			children = (
 				C37909D71828C9D80033D193 /* DSWaveformImageExample.app */,
 				C37909FB1828C9D80033D193 /* DSWaveformImageExampleTests.xctest */,
+				D6EABC491D6C010700C5862C /* DSWaveformImageFramework.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -180,7 +221,29 @@
 			path = DSWaveformImage;
 			sourceTree = "<group>";
 		};
+		D6EABC4A1D6C010700C5862C /* DSWaveformImageFramework */ = {
+			isa = PBXGroup;
+			children = (
+				D6EABC4B1D6C010700C5862C /* DSWaveformImageFramework.h */,
+				D6EABC4D1D6C010700C5862C /* Info.plist */,
+			);
+			path = DSWaveformImageFramework;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D6EABC461D6C010700C5862C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6EABC691D6C063000C5862C /* DSWaveformImage.h in Headers */,
+				D6EABC6A1D6C063600C5862C /* DSWaveformImageView.h in Headers */,
+				D6EABC4C1D6C010700C5862C /* DSWaveformImageFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		C37909D61828C9D80033D193 /* DSWaveformImageExample */ = {
@@ -190,10 +253,12 @@
 				C37909D31828C9D80033D193 /* Sources */,
 				C37909D41828C9D80033D193 /* Frameworks */,
 				C37909D51828C9D80033D193 /* Resources */,
+				D6EABC651D6C010700C5862C /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				D6EABC5D1D6C010700C5862C /* PBXTargetDependency */,
 			);
 			name = DSWaveformImageExample;
 			productName = DSWaveformImageExample;
@@ -218,6 +283,24 @@
 			productReference = C37909FB1828C9D80033D193 /* DSWaveformImageExampleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		D6EABC481D6C010700C5862C /* DSWaveformImageFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D6EABC641D6C010700C5862C /* Build configuration list for PBXNativeTarget "DSWaveformImageFramework" */;
+			buildPhases = (
+				D6EABC441D6C010700C5862C /* Sources */,
+				D6EABC451D6C010700C5862C /* Frameworks */,
+				D6EABC461D6C010700C5862C /* Headers */,
+				D6EABC471D6C010700C5862C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DSWaveformImageFramework;
+			productName = DSWaveformImageFramework;
+			productReference = D6EABC491D6C010700C5862C /* DSWaveformImageFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -225,11 +308,15 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = DS;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = dmrschmidt;
 				TargetAttributes = {
 					C37909FA1828C9D80033D193 = {
 						TestTargetID = C37909D61828C9D80033D193;
+					};
+					D6EABC481D6C010700C5862C = {
+						CreatedOnToolsVersion = 7.3.1;
 					};
 				};
 			};
@@ -248,6 +335,7 @@
 			targets = (
 				C37909D61828C9D80033D193 /* DSWaveformImageExample */,
 				C37909FA1828C9D80033D193 /* DSWaveformImageExampleTests */,
+				D6EABC481D6C010700C5862C /* DSWaveformImageFramework */,
 			);
 		};
 /* End PBXProject section */
@@ -270,6 +358,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				C3790A071828C9D80033D193 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D6EABC471D6C010700C5862C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,6 +391,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D6EABC441D6C010700C5862C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6EABC681D6C011600C5862C /* DSWaveformImageView.m in Sources */,
+				D6EABC671D6C011600C5862C /* DSWaveformImage.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -303,6 +407,11 @@
 			isa = PBXTargetDependency;
 			target = C37909D61828C9D80033D193 /* DSWaveformImageExample */;
 			targetProxy = C3790A001828C9D80033D193 /* PBXContainerItemProxy */;
+		};
+		D6EABC5D1D6C010700C5862C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D6EABC481D6C010700C5862C /* DSWaveformImageFramework */;
+			targetProxy = D6EABC5C1D6C010700C5862C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -424,6 +533,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DSWaveformImageExample/DSWaveformImageExample-Prefix.pch";
 				INFOPLIST_FILE = "DSWaveformImageExample/DSWaveformImageExample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -437,6 +547,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "DSWaveformImageExample/DSWaveformImageExample-Prefix.pch";
 				INFOPLIST_FILE = "DSWaveformImageExample/DSWaveformImageExample-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -484,6 +595,63 @@
 			};
 			name = Release;
 		};
+		D6EABC601D6C010700C5862C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = DSWaveformImageFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rhapsody.DSWaveformImageFramework;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D6EABC611D6C010700C5862C /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = DSWaveformImageFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rhapsody.DSWaveformImageFramework;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -510,6 +678,15 @@
 			buildConfigurations = (
 				C3790A101828C9D80033D193 /* Debug */,
 				C3790A111828C9D80033D193 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D6EABC641D6C010700C5862C /* Build configuration list for PBXNativeTarget "DSWaveformImageFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6EABC601D6C010700C5862C /* Debug */,
+				D6EABC611D6C010700C5862C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DSWaveformImageExample.xcodeproj/xcshareddata/xcschemes/DSWaveformImageFramework.xcscheme
+++ b/DSWaveformImageExample.xcodeproj/xcshareddata/xcschemes/DSWaveformImageFramework.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D6EABC481D6C010700C5862C"
+               BuildableName = "DSWaveformImageFramework.framework"
+               BlueprintName = "DSWaveformImageFramework"
+               ReferencedContainer = "container:DSWaveformImageExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6EABC481D6C010700C5862C"
+            BuildableName = "DSWaveformImageFramework.framework"
+            BlueprintName = "DSWaveformImageFramework"
+            ReferencedContainer = "container:DSWaveformImageExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D6EABC481D6C010700C5862C"
+            BuildableName = "DSWaveformImageFramework.framework"
+            BlueprintName = "DSWaveformImageFramework"
+            ReferencedContainer = "container:DSWaveformImageExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/DSWaveformImageFramework/DSWaveformImageFramework.h
+++ b/DSWaveformImageFramework/DSWaveformImageFramework.h
@@ -1,0 +1,21 @@
+//
+//  DSWaveformImageFramework.h
+//  DSWaveformImageFramework
+//
+//  Created by Adam Ritenauer on 8/22/16.
+//  Copyright © 2016 dmrschmidt. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "DSWaveformImage.h"
+#import "DSWaveformImageView.h"
+
+//! Project version number for DSWaveformImageFramework.
+FOUNDATION_EXPORT double DSWaveformImageFrameworkVersionNumber;
+
+//! Project version string for DSWaveformImageFramework.
+FOUNDATION_EXPORT const unsigned char DSWaveformImageFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <DSWaveformImageFramework/PublicHeader.h>
+
+

--- a/DSWaveformImageFramework/Info.plist
+++ b/DSWaveformImageFramework/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Installation
 ------------
 
 * use cocoapods `pod 'DSWaveformImage', '~> 1.0.0'`
+* use cartahge `github 'dmrschmidt/DSWaveformImage' ~> 1.1.0
 * or add the DSWaveformImage folder directly into your project (remember to add AVFoundation to your frameworks).
 
 Usage


### PR DESCRIPTION
Adds carthage support by 
- Creating a new target DSWaveformImageFramework
- Adds DSWaveformImage & DSWaveformImageView to the above target
- A new shared scheme for build
- Updates installation section of README

note: README.md references tag 1.1.0 in carthage instructions. This should be updated to match the release that this PR would be a part of.
