### PR TITLE
filtering non-audio tracks for AVAssetReaderTrackOutput

### DIFF
--- a/DSWaveformImage/DSWaveformImage/WaveformAnalyzer.swift
+++ b/DSWaveformImage/DSWaveformImage/WaveformAnalyzer.swift
@@ -18,7 +18,7 @@ struct WaveformAnalysis {
 
 class WaveformAnalyzer {
     func waveformSamples(from assetReader: AVAssetReader, count: Int, fftBands: Int?) -> WaveformAnalysis? {
-        guard let audioTrack = assetReader.asset.tracks.first else {
+        guard let audioTrack = assetReader.asset.tracks.first(where: { $0.mediaType == .audio }) else {
             return nil
         }
 


### PR DESCRIPTION
I thought wanna use this framework for mp4 video file.

AVAssetReaderTrackOutput raises NSInvalidArgumentException when analyze non-audio tracks with the outputSettings().
this fix will able to supports for movie files (.mp4 and more)

sorry for no tests...