### PR TITLE
Use UIGraphicsImageRenderer when it is available

### DIFF
--- a/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
+++ b/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
@@ -67,18 +67,34 @@ private extension WaveformImageDrawer {
     }
 
     private func graphImage(from samples: [Float], with configuration: WaveformConfiguration) -> UIImage? {
-        UIGraphicsBeginImageContextWithOptions(configuration.size, false, configuration.scale)
-        let context = UIGraphicsGetCurrentContext()!
+        if #available(iOS 10.0, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = configuration.scale
+            let renderer = UIGraphicsImageRenderer(size: configuration.size, format: format)
+
+            return renderer.image { renderContext in
+                draw(on: renderContext.cgContext, from: samples, with: configuration)
+            }
+        } else {
+            UIGraphicsBeginImageContextWithOptions(configuration.size, false, configuration.scale)
+            
+            let context = UIGraphicsGetCurrentContext()!
+            
+            draw(on: context, from: samples, with: configuration)
+
+            let graphImage = UIGraphicsGetImageFromCurrentImageContext()
+            UIGraphicsEndImageContext()
+
+            return graphImage
+        }
+    }
+    
+    private func draw(on context: CGContext, from samples: [Float], with configuration: WaveformConfiguration) {
         context.setAllowsAntialiasing(true)
         context.setShouldAntialias(true)
 
         drawBackground(on: context, with: configuration)
         drawGraph(from: samples, on: context, with: configuration)
-
-        let graphImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-
-        return graphImage
     }
 
     private func drawBackground(on context: CGContext, with configuration: WaveformConfiguration) {


### PR DESCRIPTION
Hi, thank you for your great library!

From iOS 10, we can use [UIGraphicsImageRenderer](https://developer.apple.com/documentation/uikit/uigraphicsimagerenderer) instead of `UIGraphicsBeginImageContextWithOptions`.

According to [WWDC 2018 session](https://developer.apple.com/videos/play/wwdc2018/416?time=1252), it is recommended to use `UIGraphicsImageRenderer` because it consumes only 1 byte per pixel. (`UIGraphicsBeginImageContextWithOptions` consumes 4 bytes per pixel)

So, from the performance perspective, I think it would make sense to use it when it is available 🙂