### PR TITLE
Fixes for striped drawing

### DIFF
--- a/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
+++ b/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
@@ -83,7 +83,7 @@ extension WaveformImageDrawer {
         }
 
         if case .striped = configuration.style, samples.count >= samplesNeeded {
-            lastOffset = (lastOffset + newSampleCount) % stripeBucket(configuration)
+            lastOffset = (lastOffset + min(newSampleCount, samples.count - samplesNeeded)) % stripeBucket(configuration)
         }
 
         // move the window, so that its always at the end (moves the graph after it reached the right side)

--- a/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
+++ b/DSWaveformImage/DSWaveformImage/WaveformImageDrawer.swift
@@ -76,6 +76,11 @@ extension WaveformImageDrawer {
         }
 
         let samplesNeeded = Int(configuration.size.width * configuration.scale)
+        
+        // Reset the cumulative lastOffset when new drawing begins
+        if samples.count == newSampleCount {
+            lastOffset = 0
+        }
 
         if case .striped = configuration.style, samples.count >= samplesNeeded {
             lastOffset = (lastOffset + newSampleCount) % stripeBucket(configuration)

--- a/DSWaveformImage/DSWaveformImage/WaveformLiveView.swift
+++ b/DSWaveformImage/DSWaveformImage/WaveformLiveView.swift
@@ -101,10 +101,12 @@ class WaveformLiveLayer: CALayer {
         UIGraphicsPushContext(context)
         waveformDrawer.draw(waveform: samples, newSampleCount: lastNewSampleCount, on: context, with: configuration.with(size: bounds.size))
         UIGraphicsPopContext()
+        
+        lastNewSampleCount = 0
     }
 
     func add(_ newSamples: [Float]) {
-        lastNewSampleCount = newSamples.count
+        lastNewSampleCount += newSamples.count
         samples += newSamples
     }
 


### PR DESCRIPTION
First of all, thank you for the great library. This has really helped me make must faster progress on our project than I expected. I identified a few issues around striped drawing of live waveforms and am hoping I can help someone else out by sending these fixes your way.

Lots of detail is in the individual commits, but I wanted to also include a couple of GIFs that illustrate the symptoms of the bugs to help make it clearer.

For 858c157 and d9bf439 ("Handle case where multiple samples are added between draw calls"), I was seeing drawing issues like this once `sampleCount` became greater than what could fit in the window:

![multi-sample-add-before](https://user-images.githubusercontent.com/447184/160913441-695efd0e-9d36-4e6d-a5bd-f7652c577b8b.gif)

For 0a8def3 ("Fix a blip when doing striped drawing") this is an example of what I was seeing. It's kind of subtle, but if you look closely you'll notice that the amplitude of several of the lines jumps to a different size. This is a result of a different set of samples being used due to the bug.

![blip](https://user-images.githubusercontent.com/447184/160913582-58e6d3e9-e094-494e-9a75-1f6c917b71f5.gif)