### PR TITLE
Add missing `@available` annotation for macOS in WaveformLiveCanvas view

### DIFF
--- a/Sources/DSWaveformImageViews/SwiftUI/WaveformLiveCanvas.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/WaveformLiveCanvas.swift
@@ -44,7 +44,7 @@ public struct WaveformLiveCanvas: View {
 }
 
 #if DEBUG
-@available(iOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, *)
 struct WaveformLiveCanvas_Previews: PreviewProvider {
     struct TestView: View {
         @State var show: Bool = false


### PR DESCRIPTION
Without this fix, the export of localizations gave me an error :(