### PR TITLE
feature: add the possibility to handle the "loading" state in WaveformView

### DIFF
--- a/Example/DSWaveformImageExample-iOS/SwiftUIExample/SwiftUIExampleView.swift
+++ b/Example/DSWaveformImageExample-iOS/SwiftUIExample/SwiftUIExampleView.swift
@@ -163,12 +163,10 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 1))))
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black)))) { shape in
-                        if shape.isEmpty {
-                            ProgressView()
-                        } else {
-                            shape // override the shape styling
-                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
-                        }
+                        shape // override the shape styling
+                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                    } placeholder: {
+                        ProgressView()
                     }
                 }
 
@@ -180,12 +178,10 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 2))), renderer: CircularWaveformRenderer())
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black))), renderer: CircularWaveformRenderer()) { shape in
-                        if shape.isEmpty {
-                            ProgressView()
-                        } else {
-                            shape // override the shape styling
-                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
-                        }
+                        shape // override the shape styling
+                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                    } placeholder: {
+                        ProgressView()
                     }
                 }
 
@@ -197,12 +193,10 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 2))), renderer: CircularWaveformRenderer(kind: .ring(0.5)))
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black))), renderer: CircularWaveformRenderer(kind: .ring(0.5))) { shape in
-                        if shape.isEmpty {
-                            ProgressView()
-                        } else {
-                            shape // override the shape styling
-                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
-                        }
+                        shape // override the shape styling
+                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                    } placeholder: {
+                        ProgressView()
                     }
                 }
             }

--- a/Example/DSWaveformImageExample-iOS/SwiftUIExample/SwiftUIExampleView.swift
+++ b/Example/DSWaveformImageExample-iOS/SwiftUIExample/SwiftUIExampleView.swift
@@ -163,8 +163,12 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 1))))
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black)))) { shape in
-                        shape // override the shape styling
-                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        if shape.isEmpty {
+                            ProgressView()
+                        } else {
+                            shape // override the shape styling
+                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        }
                     }
                 }
 
@@ -176,8 +180,12 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 2))), renderer: CircularWaveformRenderer())
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black))), renderer: CircularWaveformRenderer()) { shape in
-                        shape // override the shape styling
-                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        if shape.isEmpty {
+                            ProgressView()
+                        } else {
+                            shape // override the shape styling
+                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        }
                     }
                 }
 
@@ -189,8 +197,12 @@ struct SwiftUIExampleView: View {
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .red, width: 2, spacing: 2))), renderer: CircularWaveformRenderer(kind: .ring(0.5)))
 
                     WaveformView(audioURL: audioURL, configuration: .init(style: .striped(.init(color: .black))), renderer: CircularWaveformRenderer(kind: .ring(0.5))) { shape in
-                        shape // override the shape styling
-                            .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        if shape.isEmpty {
+                            ProgressView()
+                        } else {
+                            shape // override the shape styling
+                                .stroke(LinearGradient(colors: [.blue, .pink], startPoint: .bottom, endPoint: .top), lineWidth: 3)
+                        }
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ WaveformView(audioURL: audioURL) { waveformShape in
 }
 ```
 
+Similar to [AsyncImage](https://developer.apple.com/documentation/swiftui/asyncimage/init(url:scale:content:placeholder:)), a placeholder can be
+set to show until the load and render operation completes successfully.
+
+```swift
+WaveformView(audioURL: audioURL) { waveformShape in
+    waveformShape
+        .stroke(LinearGradient(colors: [.red, [.green, red, orange], startPoint: .zero, endPoint: .topTrailing), lineWidth: 3)
+} placeholder: {
+    ProgressView()
+}```
+
 #### `WaveformLiveCanvas` - renders a live waveform from `(0...1)` normalized samples:
 
 ```swift

--- a/Sources/DSWaveformImageViews/SwiftUI/DefaultShapeStyler.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/DefaultShapeStyler.swift
@@ -2,9 +2,9 @@ import Foundation
 import DSWaveformImage
 import SwiftUI
 
-struct DefaultShapeStyler {
+public struct DefaultShapeStyler {
     @ViewBuilder
-    func style(shape: WaveformShape, with configuration: Waveform.Configuration) -> some View {
+    public func style(shape: WaveformShape, with configuration: Waveform.Configuration) -> some View {
         switch configuration.style {
         case let .filled(color):
             shape.fill(Color(color))

--- a/Sources/DSWaveformImageViews/SwiftUI/DefaultShapeStyler.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/DefaultShapeStyler.swift
@@ -2,9 +2,9 @@ import Foundation
 import DSWaveformImage
 import SwiftUI
 
-public struct DefaultShapeStyler {
+struct DefaultShapeStyler {
     @ViewBuilder
-    public func style(shape: WaveformShape, with configuration: Waveform.Configuration) -> some View {
+    func style(shape: WaveformShape, with configuration: Waveform.Configuration) -> some View {
         switch configuration.style {
         case let .filled(color):
             shape.fill(Color(color))

--- a/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
@@ -29,7 +29,7 @@ public struct WaveformShape: Shape {
     }
     
     /// Whether the shape has no underlying samples to display.
-    public var isEmpty: Bool {
+    var isEmpty: Bool {
         samples.isEmpty
     }
 }

--- a/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
@@ -27,7 +27,7 @@ public struct WaveformShape: Shape {
 
         return Path(path)
     }
-    
+
     /// Whether the shape has no underlying samples to display.
     var isEmpty: Bool {
         samples.isEmpty

--- a/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/WaveformShape.swift
@@ -27,6 +27,11 @@ public struct WaveformShape: Shape {
 
         return Path(path)
     }
+    
+    /// Whether the shape has no underlying samples to display.
+    public var isEmpty: Bool {
+        samples.isEmpty
+    }
 }
 
 private extension WaveformShape {

--- a/Sources/DSWaveformImageViews/SwiftUI/WaveformView.swift
+++ b/Sources/DSWaveformImageViews/SwiftUI/WaveformView.swift
@@ -8,11 +8,9 @@ public struct WaveformView<Content: View>: View {
     private let configuration: Waveform.Configuration
     private let renderer: WaveformRenderer
     private let priority: TaskPriority
-    private let content: ((WaveformShape) -> Content)?
+    private let content: (WaveformShape) -> Content
 
     @State private var samples: [Float] = []
-
-    private let defaultStyler = DefaultShapeStyler()
 
     /**
      Creates a new WaveformView which displays a waveform for the audio at `audioURL`.
@@ -38,40 +36,9 @@ public struct WaveformView<Content: View>: View {
         self.content = content
     }
 
-    /**
-     Creates a new WaveformView which displays a waveform for the audio at `audioURL`.
-
-     - Parameters:
-        - audioURL: The `URL` of the audio asset to be rendered.
-        - configuration: The `Waveform.Configuration` to be used for rendering.
-        - renderer: The `WaveformRenderer` implementation to be used. Defaults to `LinearWaveformRenderer`. Also comes with `CircularWaveformRenderer`.
-        - priority: The `TaskPriority` used during analyzing. Defaults to `.userInitiated`.
-     */
-    public init(
-           audioURL: URL,
-           configuration: Waveform.Configuration = Waveform.Configuration(damping: .init(percentage: 0.125, sides: .both)),
-           renderer: WaveformRenderer = LinearWaveformRenderer(),
-           priority: TaskPriority = .userInitiated
-    ) where Content == _ConditionalContent<WaveformShape, EmptyView> {
-        self.audioURL = audioURL
-        self.configuration = configuration
-        self.renderer = renderer
-        self.priority = priority
-        self.content = nil
-    }
-
     public var body: some View {
         GeometryReader { geometry in
-            Group {
-                if let content = content {
-                    content(WaveformShape(samples: samples, configuration: configuration, renderer: renderer))
-                } else {
-                    defaultStyler.style(
-                        shape: WaveformShape(samples: samples, configuration: configuration, renderer: renderer),
-                        with: configuration
-                    )
-                }
-            }
+            content(WaveformShape(samples: samples, configuration: configuration, renderer: renderer))
                 .onAppear {
                     guard samples.isEmpty else { return }
                     update(size: geometry.size, url: audioURL, configuration: configuration)
@@ -90,6 +57,82 @@ public struct WaveformView<Content: View>: View {
                 await MainActor.run { self.samples = samples }
             } catch {
                 assertionFailure(error.localizedDescription)
+            }
+        }
+    }
+}
+
+public extension WaveformView {
+    /**
+     Creates a new WaveformView which displays a waveform for the audio at `audioURL`.
+
+     - Parameters:
+        - audioURL: The `URL` of the audio asset to be rendered.
+        - configuration: The `Waveform.Configuration` to be used for rendering.
+        - renderer: The `WaveformRenderer` implementation to be used. Defaults to `LinearWaveformRenderer`. Also comes with `CircularWaveformRenderer`.
+        - priority: The `TaskPriority` used during analyzing. Defaults to `.userInitiated`.
+     */
+    init(
+        audioURL: URL,
+        configuration: Waveform.Configuration = Waveform.Configuration(damping: .init(percentage: 0.125, sides: .both)),
+        renderer: WaveformRenderer = LinearWaveformRenderer(),
+        priority: TaskPriority = .userInitiated
+    ) where Content == AnyView {
+        self.init(audioURL: audioURL, configuration: configuration, renderer: renderer, priority: priority) { shape in
+            AnyView(DefaultShapeStyler().style(shape: shape, with: configuration))
+        }
+    }
+
+    /**
+     Creates a new WaveformView which displays a waveform for the audio at `audioURL`.
+
+     - Parameters:
+        - audioURL: The `URL` of the audio asset to be rendered.
+        - configuration: The `Waveform.Configuration` to be used for rendering.
+        - renderer: The `WaveformRenderer` implementation to be used. Defaults to `LinearWaveformRenderer`. Also comes with `CircularWaveformRenderer`.
+        - priority: The `TaskPriority` used during analyzing. Defaults to `.userInitiated`.
+        - placeholder: ViewBuilder for a placeholder view during the loading phase.
+     */
+    init<Placeholder: View>(
+        audioURL: URL,
+        configuration: Waveform.Configuration = Waveform.Configuration(damping: .init(percentage: 0.125, sides: .both)),
+        renderer: WaveformRenderer = LinearWaveformRenderer(),
+        priority: TaskPriority = .userInitiated,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) where Content == _ConditionalContent<Placeholder, AnyView> {
+        self.init(audioURL: audioURL, configuration: configuration, renderer: renderer, priority: priority) { shape in
+            if shape.isEmpty {
+                placeholder()
+            } else {
+                AnyView(DefaultShapeStyler().style(shape: shape, with: configuration))
+            }
+        }
+    }
+
+    /**
+     Creates a new WaveformView which displays a waveform for the audio at `audioURL`.
+
+     - Parameters:
+        - audioURL: The `URL` of the audio asset to be rendered.
+        - configuration: The `Waveform.Configuration` to be used for rendering.
+        - renderer: The `WaveformRenderer` implementation to be used. Defaults to `LinearWaveformRenderer`. Also comes with `CircularWaveformRenderer`.
+        - priority: The `TaskPriority` used during analyzing. Defaults to `.userInitiated`.
+        - content: ViewBuilder with the WaveformShape to be customized.
+        - placeholder: ViewBuilder for a placeholder view during the loading phase.
+     */
+    init<Placeholder: View, ModifiedContent: View>(
+        audioURL: URL,
+        configuration: Waveform.Configuration = Waveform.Configuration(damping: .init(percentage: 0.125, sides: .both)),
+        renderer: WaveformRenderer = LinearWaveformRenderer(),
+        priority: TaskPriority = .userInitiated,
+        @ViewBuilder content: @escaping (WaveformShape) -> ModifiedContent,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) where Content == _ConditionalContent<Placeholder, ModifiedContent> {
+        self.init(audioURL: audioURL, configuration: configuration, renderer: renderer, priority: priority) { shape in
+            if shape.isEmpty {
+                placeholder()
+            } else {
+                content(shape)
             }
         }
     }


### PR DESCRIPTION
**Problem**
Currently when using a `WaveformView` there is apparently no way to know when the "sampling task" is done.
This may cause blank spaces in the UI since the loading isn't instant.

**Solution**
`WaveformView` already has a custom way to style a `WindowShape` (providing a closure).
`WindowShape` has now a new API `isEmpty` that allows clients to know if there is still no content.
This is similar (although not identical) to what the SwiftUI [AsyncImage](https://developer.apple.com/documentation/swiftui/asyncimage) does.
Furthermore this PR makes `DefaultShapeStyler` public, so that it's available when developers opt to provide a custom closure for styling a `WindowShape`.

**Result**
![poc](https://github.com/dmrschmidt/DSWaveformImage/assets/19324622/3ed2eca0-0a88-4ae9-9a9b-60e4665df5d4)
